### PR TITLE
More than a drawer

### DIFF
--- a/apps/squire-ui/.eslintrc.json
+++ b/apps/squire-ui/.eslintrc.json
@@ -1,3 +1,3 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": ["next/core-web-vitals"]
 }

--- a/apps/squire-ui/pages/index.tsx
+++ b/apps/squire-ui/pages/index.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image'
+import Link from 'next/link'
 import { Inter } from 'next/font/google'
 import { useEffect } from 'react'
 
@@ -47,14 +48,13 @@ export default function Home() {
       <Prompt client={client}></Prompt>
 
       <div className="mb-32 grid text-center lg:mb-0 lg:grid-cols-4 lg:text-left">
-        <a
-          href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=default-template-tw&utm_campaign=create-next-app"
+        <Link
+          href="prompts"
           className="group rounded-lg border border-transparent px-5 py-4 transition-colors hover:border-gray-300 hover:bg-gray-100 hover:dark:border-neutral-700 hover:dark:bg-neutral-800/30"
-          target="_blank"
           rel="noopener noreferrer"
         >
           <h2 className={`${inter.className} mb-3 text-2xl font-semibold`}>
-            Docs{' '}
+            Prompts{' '}
             <span className="inline-block transition-transform group-hover:translate-x-1 motion-reduce:transform-none">
               -&gt;
             </span>
@@ -62,9 +62,9 @@ export default function Home() {
           <p
             className={`${inter.className} m-0 max-w-[30ch] text-sm opacity-50`}
           >
-            Find in-depth information about Next.js features and API.
+            See all of your prompts.
           </p>
-        </a>
+        </Link>
 
         <a
           href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=default-template-tw&utm_campaign=create-next-app"

--- a/apps/squire-ui/pages/prompts/index.tsx
+++ b/apps/squire-ui/pages/prompts/index.tsx
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react'
+import { supabase } from '@squire-ui/lib/supabaseClient'
+
+export default function Prompts() {
+    const client = supabase
+    const [generations, setGenerations] = useState<any[]>([])
+
+    useEffect(() => {
+      const getGenerations = async () => {
+        const { data, error } = await supabase.from('generations').select('*'); 
+        if (!error) {
+            setGenerations(data)
+        }
+      }
+    }, [client])
+    
+
+
+    return (
+        <div>
+            <h1>Welcome to Prompts!</h1>
+        </div>
+    );
+}

--- a/apps/squire-ui/src-tauri/src/main.rs
+++ b/apps/squire-ui/src-tauri/src/main.rs
@@ -8,8 +8,28 @@ fn my_custom_command() {
   println!("I was invoked from JS!");
 }
 
+use tauri::{CustomMenuItem, Menu, MenuItem, Submenu};
+
 fn main() {
+  let quit = CustomMenuItem::new("quit".to_string(), "Quit");
+  let close = CustomMenuItem::new("close".to_string(), "Close");
+  
+  let submenu = Submenu::new("File", Menu::new().add_item(quit).add_item(close));
+  let prompts_submenu = Submenu::new(
+    "Prompts",
+    Menu::new()
+      .add_item(CustomMenuItem::new("alert", "Alert"))
+      .add_item(CustomMenuItem::new("confirm", "Confirm"))
+      .add_item(CustomMenuItem::new("prompt", "Prompt")),
+  );
+  let menu = Menu::new()
+    .add_native_item(MenuItem::Copy)
+    .add_item(CustomMenuItem::new("hide", "Hide"))
+    .add_submenu(submenu)
+    .add_submenu(prompts_submenu);
+
   tauri::Builder::default()
+    .menu(menu)
     .invoke_handler(tauri::generate_handler![my_custom_command])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");


### PR DESCRIPTION
This PR contains a lot. First, we think we have a name for the app which is Squire -- "a young [nobleman](https://www.google.com/search?q=nobleman&si=AMnBZoFm76bvId4K9j6r5bU9rVYrDzkohXEvqpskUwzOqAE7VyOAzKs0JaQTUfz-4rwi5-kUsK4l8kRMPLt6rNJuce_f0YJs1A%3D%3D&expnd=1) acting as an attendant to a knight before becoming a knight himself."

Most significantly it contains a big refactor which pulls the code out into apps. These apps at the moment are: 

- core: This is the python code containing the LangChain agent stuff. Currently we're exposing this via a FastAPI rest API, combined with a subscription to Supabase postgres changes on the front end to get the streaming tokens from OpenAI. These are parsed to logs via LangChain's callback lifecycle methods. I'm not sure how the supabase subscription will scale, so this method of subscribing to streaming response tokens is subject to change. 
- squire UI: It's clear for code assistants to work, we need robust access to the user's filesystem if they are going to be doing any of this locally. [Tauri](https://tauri.app/) seems perfect for this. We can write a Next.js app in Typescript and then compile to Rust to run as a desktop app, giving us full access to native APIs. The Next.js app can be ported to browser obviously to run wherever. 
- squire-react: We still think that certain functions might be something that some users want to add directly into their web applications. This app is a set of react components that can augment user's applications to give them some of the superpowers of the squire ui. 
- CLI: Currently this is a golang CLI, but possibly this will go away since Tauri has some built in CLI capabilities. 
